### PR TITLE
Fix msan error in Multinom

### DIFF
--- a/testu01/smultin.c
+++ b/testu01/smultin.c
@@ -2109,7 +2109,7 @@ static void Multinom (unif01_Gen * gen, smultin_Param * par,
    double UnSurHache;
    double HacheLR;                /* Dimension of hashing table */
    long i;
-   long CoMax;                    /* Maximum number of balls in any cell */
+   long CoMax = -1;                    /* Maximum number of balls in any cell */
    double X0, X;                  /* Statistics */
    DeltaIndex j;                  /* Which power divergence case */
    double SumX2[smultin_MAX_DELTA];


### PR DESCRIPTION
With a new version of llvm+clang, msan becomes more clever and catches the following use-of-uninitialized-memory error.

```
==793==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7fee2bf29ed7 in Multinom third_party/testu01/testu01_1_2_3/testu01/smultin.c:2203:7
    #1 0x7fee2bf25d6e in smultin_Multinomial third_party/testu01/testu01_1_2_3/testu01/smultin.c:2313:4
    #2 0x7fee2bf0f022 in sknuth_Permutation third_party/testu01/testu01_1_2_3/testu01/sknuth.c:639:7
```

We're invoking this as

```
  sres_Chi2* res = sres_CreateChi2();
  sknuth_Permutation(&gen_, res, p.N, p.n, p.r, p.t);
```

with `N=1`, `n=50'000'000`, `r=0`, and `t=10`.