### PR TITLE
[Fix] Update fprintf, sprintf, and printf to avoid a security warning…

### DIFF
--- a/probdist/gofw.c
+++ b/probdist/gofw.c
@@ -83,7 +83,7 @@ static void printMath2 (FILE * f, double x, double y)
    } else {
       sprintf (S, "%16.8g", x);
    }
-   fprintf (f, S);
+   fprintf (f, "%s", S);
    fprintf (f, ",     ");
 
    if (y != 0.0 && (y < 0.1 || y > 1.0)) {
@@ -93,7 +93,7 @@ static void printMath2 (FILE * f, double x, double y)
    } else {
       sprintf (S, "%16.8g", y);
    }
-   fprintf (f, S);
+   fprintf (f, "%s", S);
    fprintf (f, " }");
 }
 
@@ -613,7 +613,7 @@ void gofw_WriteActiveTests2 (long N, gofw_TestArray sVal,
 {
    printf ("\n-----------------------------------------------\n");
    if (N == 1) {
-      printf (S);
+      printf ("%s", S);
       gofw_Writep2 (sVal[gofw_Mean], pVal[gofw_Mean]);
    } else {
       gofw_WriteActiveTests0 (N, sVal, pVal);

--- a/testu01/scatter.c
+++ b/testu01/scatter.c
@@ -412,7 +412,7 @@ static void BottomGraphTex (
    /* Replace the _ in the generator name by \_ for Latex */
    mystr_Subst (Title, "_", "\\_");
    mystr_Subst (Title, "01_", "01\\_");
-   fprintf (f, Title);
+   fprintf (f, "%s", Title);
 
    fprintf (f, "\n\nHypercube in %1d dimensions.\\\\\n", scatter_t);
    fprintf (f, " Over = ");
@@ -543,16 +543,16 @@ static void HeadGraphGnu (
          *p = '\0';
          len = strlen (q);
          if (len > 0) {
-            fprintf (f, q);
+            fprintf (f, "%s", q);
             fprintf (f, ";\\n");
          }
          p++;
          q = p;
          p = strchr (q, '\n');
       }
-      fprintf (f, q);
+      fprintf (f, "%s", q);
    } else
-      fprintf (f, Title);
+      fprintf (f, "%s", Title);
 
    fprintf (f, ";\\n   N = %1ld", scatter_N);
    fprintf (f, "; t = %1d", scatter_t);
@@ -582,14 +582,14 @@ static void HeadGraphGnu (
       strcat (Nout3, ".ps");
       /* Postscript file for figure */
       fprintf (f, "set output \"");
-      fprintf (f, Nout3);
+      fprintf (f, "%s", Nout3);
       fprintf (f, "\"\nset term postscript");
    } else if (scatter_Output == scatter_gnu_term) {
       fprintf (f, "set output\n");
       fprintf (f, "set term x11");
    }
    fprintf (f, "\nplot \"");
-   fprintf (f, Nout2);
+   fprintf (f, "%s", Nout2);
    fprintf (f, "\"\n");
    if (scatter_Output == scatter_gnu_term) {
       fprintf (f, "pause -1  \"Hit return to continue \"\n");

--- a/testu01/swrite.c
+++ b/testu01/swrite.c
@@ -136,7 +136,7 @@ void swrite_Chi2SumTest (long N, sres_Chi2 *res)
       return;
    printf ("Test on the sum of all N observations\n");
    swrite_AddStrChi (str, LENGTH, N*res->degFree);
-   printf (str);
+   printf ("%s", str);
    gofw_Writep2 (res->sVal2[gofw_Sum], res->pVal2[gofw_Sum]);
 }
 
@@ -150,7 +150,7 @@ void swrite_Chi2SumTestb (long N, double sval, double pval, long degFree)
       return;
    printf ("Test on the sum of all N observations\n");
    swrite_AddStrChi (str, LENGTH, N*degFree);
-   printf (str);
+   printf ("%s", str);
    gofw_Writep2 (sval, pval);
 }
 


### PR DESCRIPTION
… when compiling with GCC.

Security warning complains about a variable being used for the format string since it could contain format parameters which would cause bad reads. Fix is simply to provide "%s" as the format string and the original argument as a parameter.