### PR TITLE
fix: tcode is located in top_builddir, not top_srcdir.

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,11 +1,11 @@
 %.h: ${MYLIB}/%.tex
-	${top_srcdir}/tcode $< $@
+	${top_builddir}/tcode $< $@
 
 %.h: ${PROBDIST}/%.tex
-	${top_srcdir}/tcode $< $@
+	${top_builddir}/tcode $< $@
 
 %.h: ${TESTU01}/%.tex
-	${top_srcdir}/tcode $< $@
+	${top_builddir}/tcode $< $@
 
 include Makefile.def
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -472,13 +472,14 @@ uninstall-am: uninstall-includeHEADERS
 	ps ps-am tags uninstall uninstall-am uninstall-includeHEADERS
 
 %.h: ${MYLIB}/%.tex
-	${top_srcdir}/tcode $< $@
+	${top_builddir}/tcode $< $@
 
 %.h: ${PROBDIST}/%.tex
-	${top_srcdir}/tcode $< $@
+	${top_builddir}/tcode $< $@
 
 %.h: ${TESTU01}/%.tex
-	${top_srcdir}/tcode $< $@
+	${top_builddir}/tcode $< $@
+
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.
 .NOEXPORT:


### PR DESCRIPTION
GNU autoconf allows to build a software in a dedicated, new build folder. This can be used in situations where more than one configuration should be built, or when it is undesirable to clutter up the source directory with built files all over the place.

In such a layout, the built tcode executable is located in builddir, not srcdir.  This error will only come apparent when configure is not run in srcdir.  When srcdir = builddir, the patch has (effectively) no effect.

	* include/Makefile.am: Use top_buiddir instead of top_srcdir in the path to tcode.