### PR TITLE
Generator names should be passed as const char* and not as char*.

### DIFF
--- a/testu01/unif01.c
+++ b/testu01/unif01.c
@@ -1210,7 +1210,7 @@ static unsigned long GB_Bits (void *junk1, void *junk2)
 }
 
 
-unif01_Gen *unif01_CreateExternGenBits (const const char *name,
+unif01_Gen *unif01_CreateExternGenBits (const char *name,
     unsigned int (*f_Bits)(void))
 {
    unif01_Gen *gen;

--- a/testu01/unif01.c
+++ b/testu01/unif01.c
@@ -1155,7 +1155,7 @@ static void WrExternGen (void *junk2)
 }
 
 
-unif01_Gen *unif01_CreateExternGen01 (char *name, double (*f_U01)(void))
+unif01_Gen *unif01_CreateExternGen01 (const char *name, double (*f_U01)(void))
 {
    unif01_Gen *gen;
    size_t leng;
@@ -1210,7 +1210,7 @@ static unsigned long GB_Bits (void *junk1, void *junk2)
 }
 
 
-unif01_Gen *unif01_CreateExternGenBits (char *name,
+unif01_Gen *unif01_CreateExternGenBits (const const char *name,
     unsigned int (*f_Bits)(void))
 {
    unif01_Gen *gen;
@@ -1266,7 +1266,7 @@ static unsigned long GBLong_Bits (void *junk1, void *junk2)
 }
 
 
-unif01_Gen *unif01_CreateExternGenBitsL (char *name,
+unif01_Gen *unif01_CreateExternGenBitsL (const char *name,
     unsigned long (*f_Bits)(void))
 {
    unif01_Gen *gen;

--- a/testu01/unif01.tex
+++ b/testu01/unif01.tex
@@ -573,7 +573,7 @@ unpredictable. % Similarly, a generator should not be so pathological so as to
 \code
 
 
-unif01_Gen *unif01_CreateExternGen01 (char *name, double (*gen01)(void));
+unif01_Gen *unif01_CreateExternGen01 (const char *name, double (*gen01)(void));
 \endcode
 \tab Implements a pre-existing external generator {\tt gen01} that is
   not part of TestU01. \label{externgen}
@@ -584,7 +584,7 @@ unif01_Gen *unif01_CreateExternGen01 (char *name, double (*gen01)(void));
 \code
 
 
-unif01_Gen *unif01_CreateExternGenBits (char *name,
+unif01_Gen *unif01_CreateExternGenBits (const char *name,
                                         unsigned int (*genB)(void));
 \endcode
 \tab Implements a pre-existing external generator {\tt genB} that is not part
@@ -598,7 +598,7 @@ unif01_Gen *unif01_CreateExternGenBits (char *name,
 \code
 
 
-unif01_Gen *unif01_CreateExternGenBitsL (char *name,
+unif01_Gen *unif01_CreateExternGenBitsL (const char *name,
                                          unsigned long (*genB)(void));
 \endcode
 \tab Similar to {\tt unif01\_CreateExternGenBits}, but with


### PR DESCRIPTION
Functions like unif01_CreateExternGen01 have currently a prototype of

   unif01_Gen *unif01_CreateExternGen01 (char *name, double (*f_U01)(void))

i.e. they are alloed to change the string pointed to by name. This is not expected, and these functions actually DO NOT change the contents of name.  Therefore, name should be const qualified:

   unif01_Gen *unif01_CreateExternGen01 (const char *name, double (*f_U01)(void))

As a simple test case, consider

unsigned myrand (void)
{
   static unsigned u;
   return ++u;
}

const char myrand_name[] = "myrand";

unif01_Gen *gen_myrand (void)
{
   return unif01_CreateExternGenBits (myrand_name, myrand);
}

testu01.c: In function 'gen_myrand':
testu01.c:13:40: warning: passing argument 1 of 'unif01_CreateExternGenBits' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   13 |     return unif01_CreateExternGenBits (myrand_name, myrand);
      |                                        ^~~~~~~~~~~
In file included from testu01.c:1:
$prefix/include/unif01.h:147:47: note: expected 'char *' but argument is of type 'const char *'
  147 | unif01_Gen *unif01_CreateExternGenBits (char *name,
      |                                         ~~~~~~^~~~

	* testu01/unif01.c (unif01_CreateExternGen01) (unif01_CreateExternGenBits, unif01_CreateExternGenBitsL): Pass name as const char* instead of as char*.
	* testu01/unif01.tex: Same.