### PR TITLE
Fix strncat build warnings when building with gcc.

### DIFF
--- a/mylib/gdef.c
+++ b/mylib/gdef.c
@@ -58,7 +58,7 @@ void gdef_GetHostName (char machine[], int n)
       strncpy (machine, Z.nodename, (size_t) n);
       j = strlen (machine);
       if (n - j > 2)
-         strncat (machine, ", ", (size_t) 2);
+         strncat (machine, ", ", (size_t) 3);
       j = strlen (machine);
       if (n - j > 0)
          strncat (machine, Z.sysname, (size_t) (n - j));

--- a/testu01/svaria.c
+++ b/testu01/svaria.c
@@ -418,7 +418,7 @@ void svaria_SumLogs (unif01_Gen * gen, sres_Chi2 * res,
 
    strncpy (chaine, "SumLogs sVal1:   chi2 with ", (size_t) LEN1);
    sprintf (str, "%ld", 2 * n);
-   strncat (chaine, str, (size_t) LEN2);
+   strncat (chaine, str, (size_t) LEN1);
    strncat (chaine, " degrees of freedom", (size_t) LEN1);
    statcoll_SetDesc (res->sVal1, chaine);
    res->degFree = 2 * n;
@@ -538,7 +538,7 @@ void svaria_WeightDistrib (unif01_Gen * gen, sres_Chi2 * res,
 
    strncpy (chaine, "WeightDistrib sVal1:   chi2 with ", (size_t) LEN1);
    sprintf (str, "%ld", NbClasses - 1);
-   strncat (chaine, str, (size_t) LEN2);
+   strncat (chaine, str, (size_t) LEN1);
    strncat (chaine, " degrees of freedom", (size_t) LEN1);
    statcoll_SetDesc (res->sVal1, chaine);
    res->degFree = NbClasses - 1;
@@ -681,7 +681,7 @@ static int svaria_CollisionArgMax_00 (unif01_Gen *gen, sres_Chi2 *res,
 
    strncpy (chaine, "CollisionArgMax sVal1:   chi2 with ", (size_t) LEN1);
    sprintf (str, "%ld", NbClasses - 1);
-   strncat (chaine, str, (size_t) LEN2);
+   strncat (chaine, str, (size_t) LEN1);
    strncat (chaine, " degrees of freedom", (size_t) LEN1);
    statcoll_SetDesc (res->sVal1, chaine);
    res->degFree = NbClasses - 1;
@@ -889,7 +889,7 @@ void svaria_SumCollector (unif01_Gen * gen, sres_Chi2 * res,
 
    strncpy (chaine, "SumCollector sVal1:   chi2 with ", (size_t) LEN1);
    sprintf (str, "%ld", NbClasses - 1);
-   strncat (chaine, str, (size_t) LEN2);
+   strncat (chaine, str, (size_t) LEN1);
    strncat (chaine, " degrees of freedom", (size_t) LEN1);
    statcoll_SetDesc (res->sVal1, chaine);
    res->degFree = NbClasses - 1;

--- a/testu01/ubrent.c
+++ b/testu01/ubrent.c
@@ -723,7 +723,7 @@ unif01_Gen * ubrent_CreateXorgen64 (int r, int s, int a, int b, int c, int d,
    if (hasWeyl)
       strncat (name, "TRUE", 5);
    else
-      strncat (name, "FALSE", 5);
+      strncat (name, "FALSE", 6);
    addstr_ULONG (name, ",  seed = ", seed);
    leng = strlen (name);
    gen->name = util_Calloc (leng + 1, sizeof (char));

--- a/testu01/ulec.c
+++ b/testu01/ulec.c
@@ -2162,7 +2162,7 @@ unif01_Gen * ulec_CreateMRG31k3p (long x10, long x11,
    addstr_Long (name, ", ", x20);
    addstr_Long (name, ", ", x21);
    addstr_Long (name, ", ", x22);
-   strncat (name, ")", (size_t) 1);
+   strncat (name, ")", (size_t) 2);
    leng = strlen (name);
    gen->name = util_Calloc (leng + 1, sizeof (char));
    strncpy (gen->name, name, leng);

--- a/testu01/unif01.c
+++ b/testu01/unif01.c
@@ -208,7 +208,7 @@ unif01_Gen * unif01_CreateDoubleGen2 (unif01_Gen *gen, double v)
    len += len3;
    name = util_Calloc (len + 1, sizeof (char));
    strncpy (name, gen->name, len);
-   strncat (name, "\nunif01_CreateDoubleGen2 with h = ", len2);
+   strncat (name, "\nunif01_CreateDoubleGen2 with h = ", 1 + len2);
    strncat (name, str, len3);
 
    /* The state of the double generator is simply the state of the original
@@ -243,7 +243,7 @@ unif01_Gen * unif01_CreateDoubleGen (unif01_Gen *gen, int s)
    len += len3;
    name = util_Calloc (len + 1, sizeof (char));
    strncpy (name, gen->name, len);
-   strncat (name, "\nunif01_CreateDoubleGen with s = ", len2);
+   strncat (name, "\nunif01_CreateDoubleGen with s = ", 1 + len2);
    strncat (name, str, len3);
    genD->name    = name;
    return genD;
@@ -357,7 +357,7 @@ unif01_Gen * unif01_CreateLacGen (unif01_Gen *gen, int k, long I[])
    strncpy (name, gen->name, len);
    len2 = strlen ("\nunif01_CreateLacGen with k = ");
    len += len2;
-   strncat (name, "\nunif01_CreateLacGen with k = ", len2);
+   strncat (name, "\nunif01_CreateLacGen with k = ", 1 + len2);
    sprintf (str, "%-d", k);
    strncat (name, str, 16);
    strncat (name, ", I = (", 8);
@@ -366,9 +366,9 @@ unif01_Gen * unif01_CreateLacGen (unif01_Gen *gen, int k, long I[])
       sprintf (str, "%-ld", I[j]);
       strncat (name, str, 16);
       if (j < k - 1)
-         strncat (name, ", ", 2);
+         strncat (name, ", ", 3);
       else
-         strncat (name, ")", 1);
+         strncat (name, ")", 2);
    }
 
    len = strlen (name);
@@ -463,10 +463,10 @@ unif01_Gen * unif01_CreateBiasGen (unif01_Gen *gen, double a, double R)
 
    strncpy (name, gen->name, LEN0);
    len = strlen ("\nunif01_CreateBiasGen with  P = ");
-   strncat (name, "\nunif01_CreateBiasGen with  P = ", len);
+   strncat (name, "\nunif01_CreateBiasGen with  P = ", 1 + len);
    sprintf (str, "%.4f", R);
    len = strlen (str);
-   strncat (name, str, len);
+   strncat (name, str, 1 + len);
    strncat (name, ",  a = ", 8);
    sprintf (str, "%.4f", a);
    len = strlen (str);
@@ -555,7 +555,7 @@ unif01_Gen * unif01_CreateLuxGen (unif01_Gen *gen, int k, int L)
 
    strncpy (name, gen->name, LEN0);
    len = strlen ("\nunif01_CreateLuxGen:   k = ");
-   strncat (name, "\nunif01_CreateLuxGen:   k = ", len);
+   strncat (name, "\nunif01_CreateLuxGen:   k = ", 1 + len);
    sprintf (str, "%-d,   L = %-d", k, L);
    len = strlen (str);
    strncat (name, str, len);
@@ -755,7 +755,7 @@ unif01_Gen * unif01_CreateBitBlockGen (unif01_Gen *gen, int r, int s, int w)
    len += len3;
    name = util_Calloc (len + 1, sizeof (char));
    strncpy (name, gen->name, len);
-   strncat (name, "\nunif01_CreateBitBlockGen:   ", len2);
+   strncat (name, "\nunif01_CreateBitBlockGen:   ", 1 + len2);
    strncat (name, str, len3);
    genV->name    = name;
    genV->param   = paramV;


### PR DESCRIPTION
There are several places where suspect len arguments to strncat are specified, like for example in mylib/gdef.c::gdef_GetHostName():

	   strncat (machine, ", ", (size_t) 2);

The semantics of strncat is that it writes at most 2 chars from ", " *plus* an additional terminating '\0' as needed.  This is 3 chars, presumably what the authors intended.  The obvious approach here would be to just use strcat for small static strings like in the sample, though the patch keeps the current coding style with strncat.

	* mylib/gdef.c (gdef_GetHostName): Use proper len specification in strncat calls, i.e. pass the size of the source rather than the length.
	* testu01/ubrent.c (ubrent_CreateXorgen64): Same.
	* testu01/ulec.c (ulec_CreateMRG31k3p): Same.
	* testu01/unif01.c (unif01_CreateLacGen,  unif01_CreateBiasGen) (unif01_CreateDoubleGen2, unif01_CreateDoubleGen): Same.
	* testu01/svaria.c (svaria_SumLogs, svaria_WeightDistrib) (svaria_CollisionArgMax_00, svaria_SumCollector): When writing to chaine[], use the length of chaine[], i.e. LEN1 in strncat, instead of LEN2 which exceeds the length of chaine[].